### PR TITLE
updated handling for Update and Create UI 

### DIFF
--- a/assets/scripts/item/ui.js
+++ b/assets/scripts/item/ui.js
@@ -49,6 +49,8 @@ const resetUiHandleing = function () {
   $('#itemTitle').html('Item Inventory')
   $('#createModalLabel').css('color', 'black')
   $('#createModalLabel').html('Create Item')
+  $('.update-form')[0].reset()
+  $('#create-item-form')[0].reset()
 }
 
 module.exports = {


### PR DESCRIPTION
modals clear if you click close before clicking create or update so user does not get a repopulated modal on next click